### PR TITLE
Update search.cpp

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -296,7 +296,7 @@ std::string Searcher::pvInfoToUSI(Position& pos, const Ply depth, const Score al
 			ss << " " << rootMoves[i].pv_[j].toUSI();
 		}
 
-		ss << std::endl;
+		// ss << std::endl;
 	}
 	return ss.str();
 }


### PR DESCRIPTION
deleting all "\n"  (empty lines) from usi output permits to use Apery Engine with gShogi on linux! (it also fixes "no valid usi engine" error)
